### PR TITLE
Brier score loss bug

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1877,7 +1877,7 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
 
     pos_label : int or str, default=None
         Label of the positive class. If None, the maximum label is used as
-        positive class
+        positive class. If all values are 0/False, then 1 is used as pos_label.
 
     Returns
     -------
@@ -1911,8 +1911,12 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
     assert_all_finite(y_true)
     assert_all_finite(y_prob)
 
-    if pos_label is None:
-        pos_label = y_true.max()
+    y_true_max = y_true.max()
+    if pos_label is None and y_true_max != 0:
+        pos_label = y_true_max
+    else:
+        pos_label = 1
+
     y_true = np.array(y_true == pos_label, int)
-    y_true = _check_binary_probabilistic_predictions(y_true, y_prob)
+    _check_binary_probabilistic_predictions(y_true, y_prob)
     return np.average((y_true - y_prob) ** 2, weights=sample_weight)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1578,3 +1578,33 @@ def test_brier_score_loss():
     # calculate even if only single class in y_true (#6980)
     assert_almost_equal(brier_score_loss([0], [0.5]), 0.25)
     assert_almost_equal(brier_score_loss([1], [0.5]), 0.25)
+
+
+def test_brier_score_loss():
+    # Check brier_score_loss function
+    y_true = np.array([0, 1, 1, 0, 1, 1])
+    y_pred = np.array([0.1, 0.8, 0.9, 0.3, 1., 0.95])
+    true_score = linalg.norm(y_true - y_pred) ** 2 / len(y_true)
+
+    assert_almost_equal(brier_score_loss(y_true, y_true), 0.0)
+    assert_almost_equal(brier_score_loss(y_true, y_pred), true_score)
+    assert_almost_equal(brier_score_loss(1. + y_true, y_pred),
+                        true_score)
+    assert_almost_equal(brier_score_loss(2 * y_true - 1, y_pred),
+                        true_score)
+    assert_raises(ValueError, brier_score_loss, y_true, y_pred[1:])
+    assert_raises(ValueError, brier_score_loss, y_true, y_pred + 1.)
+    assert_raises(ValueError, brier_score_loss, y_true, y_pred - 1.)
+    # calculate even if only single class in y_true (#6980)
+    assert_almost_equal(brier_score_loss([0], [0.5]), 0.25)
+    assert_almost_equal(brier_score_loss([1], [0.5]), 0.25)
+
+    # brier_score_loss should work when all inputs are the same
+    assert_almost_equal(brier_score_loss(np.array([0, 0, 0]), np.array([0, 0, 0])), 0)
+    assert_almost_equal(brier_score_loss(np.array([0, 0, 0]), np.array([1, 1, 1])), 1)
+    assert_almost_equal(brier_score_loss(np.array([1, 1, 1]), np.array([1, 1, 1])), 0)
+    assert_almost_equal(brier_score_loss(np.array([1, 1, 1]), np.array([0, 0, 0])), 1)
+
+    # test for when y_true is not 0s and 1s
+    assert_almost_equal(brier_score_loss(np.array([3, 0, 3]), np.array([1, 0, 1])), 0)
+    assert_almost_equal(brier_score_loss(np.array([3, 2, 3]), np.array([1, 0, 1])), 0)


### PR DESCRIPTION
This is in reference to this [bug report](https://github.com/scikit-learn/scikit-learn/issues/9300).

Some of the added tests would not pass using the current version of `brier_score_loss`. I have added a potential fix for the issue. The solution isn't too pretty, but the only alternative I can see is to change the `label_binarizer` function in a way that is probably undesirable.